### PR TITLE
Fix Python 2.6

### DIFF
--- a/pytest_raisesregexp/plugin.py
+++ b/pytest_raisesregexp/plugin.py
@@ -23,17 +23,17 @@ class raises_regexp(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         __tracebackhide__ = True
         if exc_type is None:
-            pytest.fail('DID NOT RAISE {}'.format(self.exception))
+            pytest.fail('DID NOT RAISE {0}'.format(self.exception))
 
         self.excinfo.__init__((exc_type, exc_val, exc_tb))
 
         if not issubclass(exc_type, self.exception):
-            pytest.fail('{} RAISED instead of {}\n{}'.format(exc_type,
-                                                             self.exception,
-                                                             repr(exc_val)))
+            pytest.fail('{0} RAISED instead of {1}\n{2}'.format(exc_type,
+                                                                self.exception,
+                                                                repr(exc_val)))
 
         if not re.search(self.regexp, str(exc_val)):
-            pytest.fail('Pattern "{}" not found in "{}"'.format(self.regexp,
-                                                                str(exc_val)))
+            pytest.fail('Pattern "{0}" not found in "{1}"'.format(self.regexp,
+                                                                  str(exc_val)))
 
         return True


### PR DESCRIPTION
Hi György,

thank you for this small but very useful plugin!

I've just stumbled upon a problem. Python 2.6 doesn't understand patterns like `Pattern "{}" not found in "{}"'`, it needs either named or numbered fields. Currently a failed assertion about an error wrapped in `raises_regexp()` triggers `ValueError: zero length field name in format` under py26.

I'm not a big fan of Python 2.6 and I stick to Py3 whenever possible, but I see no reason to drop support for the older Python, for instance, in my [Monk](http://github.com/neithere/monk) library. So it would be great if pytest_raisesregexp could be also tolerant to the old and senile Python.

Thanks!

Andy
