### PR TITLE
Allow functional (inline) syntax

### DIFF
--- a/pytest_raisesregexp/plugin.py
+++ b/pytest_raisesregexp/plugin.py
@@ -11,10 +11,14 @@ def pytest_namespace():
 
 
 class raises_regexp(object):
-    def __init__(self, expected_exception, regexp):
+    def __init__(self, expected_exception, regexp, *args, **kwargs):
+        __tracebackhide__ = True
         self.exception = expected_exception
         self.regexp = regexp
         self.excinfo = None
+        if args:
+            with self:
+                args[0](*args[1:], **kwargs)
 
     def __enter__(self):
         self.excinfo = object.__new__(py.code.ExceptionInfo)


### PR DESCRIPTION
This PR adds support for the same (inline) syntax as in `pytest.raises`, e.g.:

``` python
pytest.raises_regexp(ValueError, 'foo', func, x, y, a=1, b=2)
```
